### PR TITLE
Replace prompt sigil with gt character

### DIFF
--- a/zsh/prompt/novalis.zsh
+++ b/zsh/prompt/novalis.zsh
@@ -50,7 +50,7 @@ function prompt_novalis_setup {
 
   # Define prompts.
   PROMPT="$PROMPT in %F{green}%~%f%F{yellow}%(1j. ★%j.)%f "'${vcs_info_msg_0_}'"
-%(?.%F{green}.%F{red}%? )%(!.#.❯)%f "
+%(?.%F{green}.%F{red}%? )%(!.#.>)%f "
 
   RPROMPT=''
 }


### PR DESCRIPTION
Not all fonts support this particular sigil. (Go mono being one of them)